### PR TITLE
Prettier parse errors using instaparse-cljs 1.3.5.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/clojurescript "0.0-3211"]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]
-                 [com.lucasbradstreet/instaparse-cljs "1.3.5"]
+                 [com.lucasbradstreet/instaparse-cljs "1.3.5.1"]
                  #_[kibu/pushy "0.3.1"]
                  #_[secretary "1.2.3"]
                  [cljsjs/codemirror "5.1.0-2"]

--- a/src/app/util.cljs
+++ b/src/app/util.cljs
@@ -1,9 +1,9 @@
 (ns app.util
-  (:require [clojure.string :as str]
+  (:require [instaparse.core :as insta]
+            [re-com.core   :refer [h-box v-box box gap line scroller border h-split v-split title flex-child-style p]]
             [clojure.walk :refer [postwalk]]
-            [instaparse.core :as insta]
             [reagent.core :as r]
-            [re-com.core   :refer [h-box v-box box gap line scroller border h-split v-split title flex-child-style p]]))
+            ))
 
 (enable-console-print!)
 

--- a/src/app/util.cljs
+++ b/src/app/util.cljs
@@ -1,13 +1,18 @@
 (ns app.util
-  (:require [instaparse.core :as insta]
-            [re-com.core   :refer [h-box v-box box gap line scroller border h-split v-split title flex-child-style p]]
-
+  (:require [clojure.string :as str]
             [clojure.walk :refer [postwalk]]
+            [instaparse.core :as insta]
             [reagent.core :as r]
-            ))
+            [re-com.core   :refer [h-box v-box box gap line scroller border h-split v-split title flex-child-style p]]))
 
 (enable-console-print!)
 
+(defn error-message
+  [error-msg]
+  [:div {:style {:padding 5
+                 :font-family "Courier New"
+                 :white-space "pre"}}
+   error-msg])
 
 (defn parse [rules sample]
   (try
@@ -15,20 +20,8 @@
           result (insta/parses parser sample)
           failure? (insta/failure? result)]
       (if failure?
-        (let [result (into {} (insta/get-failure result))]
-          (if (string? result) result
-                               (vec (concat
-                                      [:div {:class "parse-failure"}]
-                                      [[:div
-                                        [:strong "Line "] (:line result)
-                                        [:strong ", index "] (:index result)
-                                        [:strong ", column "] (:column result)
-                                        ]
-                                       [:div {:style {:marginLeft 10}} (map (fn [reason]
-                                                                              (let [tag (name (:tag reason))
-                                                                                    expected (with-out-str (prn (:expecting reason)))]
-                                                                                [:div [:strong tag] " expected " expected])) (:reason result))]
-                                       [:div [:strong "Text: "] (:text result)]]))))
+        (let [result (insta/get-failure result)]
+          (error-message (pr-str result)))
         (let [result (postwalk
                        (fn [x]
                          (if (vector? x) [:div {:class (str "parse-tag " (name (first x)))}
@@ -38,7 +31,7 @@
     (catch :default e
       (do
         (prn "Caught error:" e)
-        [:div {:style {:padding 5}} (str e)]))))
+        (error-message e)))))
 
 (def cm-defaults {
                   :lineNumbers false


### PR DESCRIPTION
Thanks to lbradstreet/instaparse-cljs#4, Instaparse failure objects are now pretty-printed, just like the Clojure version. This also means that the error messages from bad grammars now contain a prettier parse error in the thrown string. Instaparse-live should be able to use both of these improvements to display parse errors that more closely resembles using Instaparse in a REPL.

In this patch, I propose having the parse errors AND EBNF errors both display their error message in Courier New as the output. As I am not a style expert, please let me know if that is less aesthetically appealing to you (but I think it still looks really slick). Maybe the error message should be displayed in red as a bonus... I'll leave that up to you :)

After this patch, it's very easy to interactively create parsers and inputs for the parsers, because you can see the caret move as you type, dictating what the parser is expecting next.
